### PR TITLE
feat: add infracost1 and infracost2 packages for v1/v2 split

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -1,0 +1,16 @@
+name: Release v2
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [infracost2_choco]
+
+jobs:
+  build:
+    name: Release Infracost CLI v2 choco
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate & push
+        run: infracost2/build.ps1
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,13 @@ jobs:
         run: infracost/build.ps1
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+
+  build-v1:
+    name: Release Infracost CLI v1 choco
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate & push
+        run: infracost1/build.ps1
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}

--- a/infracost1/build.ps1
+++ b/infracost1/build.ps1
@@ -1,0 +1,48 @@
+# this script updates powershell and nuspec files found in the templates folder to the latest version of Infracost CLI v1.
+
+$zip = "infracost-windows-amd64.zip"
+$shafile = "$($zip).sha256"
+$version = (Invoke-Webrequest https://api.github.com/repos/infracost/infracost/releases/latest | convertfrom-json).name
+
+Write-Host "$(get-date) - downloading release $version"
+Invoke-WebRequest -uri "https://github.com/infracost/infracost/releases/download/$($version)/$($zip)" -OutFile $zip
+Invoke-WebRequest -uri "https://github.com/infracost/infracost/releases/download/$($version)/$($shafile)" -OutFile $shafile
+
+$sha = (Get-FileHash $zip).Hash
+$contents = (Get-Content $shafile)
+if ("$($sha)  $($zip)" -ne $contents) {
+  Write-Host "sha of $($sha) mismatched for downloaded artefact contents: $($contents)"
+  exit 1
+}
+
+if (Test-Path -Path ".\tools") {
+  Remove-Item .\tools -Recurse
+}
+New-Item .\tools -ItemType "directory"
+
+# removing the first v as chocolatey doesnt like this version
+$chocoVersion = $version.Substring(1, ($version.Length-1));
+
+function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
+$templatePath = Join-Path (Get-ScriptDirectory) ".\templates"
+
+Get-Content "$($templatePath)\chocolateyinstall.ps1" | %{$_ -replace "{PLACEHOLDER_VERSION}",$version} | %{$_ -replace "{PLACEHOLDER_SHA}", $sha} | Out-File .\tools\chocolateyinstall.ps1
+Get-Content "$($templatePath)\infracost1.nuspec" | %{$_ -replace "{PLACEHOLDER_VERSION}",$chocoVersion} | Out-File .\infracost1.nuspec
+
+Write-Host "$(get-date) - Building choco pkg"
+choco pack --version $chocoVersion
+
+Write-Host "$(get-date) - Testing choco pkg is valid"
+choco install infracost1 -dv -s .
+
+$out = (infracost --version)
+if ("Infracost $($version)" -ne $out) {
+  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'Infracost $($version)'"
+  exit 1
+}
+
+Write-Host "$(get-date) - Test install of infracost passed --version check: $($out)"
+
+Get-ChildItem *.nupkg
+Write-Host "$(get-date) - Pushing to Chocolatey"
+choco push -s https://push.chocolatey.org/ --api-key=$env:CHOCO_API_KEY

--- a/infracost1/templates/chocolateyinstall.ps1
+++ b/infracost1/templates/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$url64 = "https://github.com/infracost/infracost/releases/download/{PLACEHOLDER_VERSION}/infracost-windows-amd64.zip"
+$unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+$packageParams = @{
+  PackageName   = 'infracost1'
+  UnzipLocation = $unzipLocation
+  Url64         = $url64
+  Checksum64    = '{PLACEHOLDER_SHA}'
+  ChecksumType  = 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageParams

--- a/infracost1/templates/infracost1.nuspec
+++ b/infracost1/templates/infracost1.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+	<metadata>
+		<id>infracost1</id>
+		<version>{PLACEHOLDER_VERSION}</version>
+		<packageSourceUrl>https://github.com/infracost/chocolatey-packages</packageSourceUrl>
+		<owners>infracost</owners>
+		<title>Infracost CLI v1</title>
+		<authors>Infracost</authors>
+		<projectUrl>https://infracost.io</projectUrl>
+		<iconUrl>https://rawcdn.githack.com/infracost/chocolatey-packages/master/media/icon.png</iconUrl>
+		<licenseUrl>https://github.com/infracost/infracost/blob/master/LICENSE</licenseUrl>
+		<projectSourceUrl>https://github.com/infracost/infracost</projectSourceUrl>
+		<docsUrl>https://infracost.io/docs/</docsUrl>
+		<bugTrackerUrl>https://github.com/infracost/infracost/issues</bugTrackerUrl>
+		<tags>infracost cloud infrastructure-as-code terraform iac azure aws cost cost-estimate</tags>
+		<summary>See cloud cost estimates for Terraform in pull requests.</summary>
+		<description>
+			Infracost shows cloud cost estimates for Terraform. It enables DevOps, SRE and engineers to see a cost breakdown and understand costs before making changes, either in the terminal or pull requests. This provides your team with a safety net as people can discuss costs as part of the workflow.
+		</description>
+		<releaseNotes>https://github.com/infracost/infracost/releases</releaseNotes>
+	</metadata>
+	<files>
+		<file src="tools\**" target="tools" />
+	</files>
+</package>

--- a/infracost2/build.ps1
+++ b/infracost2/build.ps1
@@ -1,0 +1,43 @@
+# this script updates powershell and nuspec files found in the templates folder to the latest version of Infracost CLI v2.
+
+$version = (Invoke-Webrequest https://api.github.com/repos/infracost/cli/releases/latest | convertfrom-json).name
+
+# strip the leading v; the bare version is used as the chocolatey package
+# version and is also embedded in the v2 asset filename
+$bareVersion = $version.Substring(1, ($version.Length-1))
+
+$zip = "infracost_$($bareVersion)_windows_amd64.zip"
+
+Write-Host "$(get-date) - downloading release $version"
+Invoke-WebRequest -uri "https://github.com/infracost/cli/releases/download/$($version)/$($zip)" -OutFile $zip
+
+$sha = (Get-FileHash $zip).Hash
+
+if (Test-Path -Path ".\tools") {
+  Remove-Item .\tools -Recurse
+}
+New-Item .\tools -ItemType "directory"
+
+function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
+$templatePath = Join-Path (Get-ScriptDirectory) ".\templates"
+
+Get-Content "$($templatePath)\chocolateyinstall.ps1" | %{$_ -replace "{PLACEHOLDER_VERSION}",$bareVersion} | %{$_ -replace "{PLACEHOLDER_SHA}", $sha} | Out-File .\tools\chocolateyinstall.ps1
+Get-Content "$($templatePath)\infracost2.nuspec" | %{$_ -replace "{PLACEHOLDER_VERSION}",$bareVersion} | Out-File .\infracost2.nuspec
+
+Write-Host "$(get-date) - Building choco pkg"
+choco pack --version $bareVersion
+
+Write-Host "$(get-date) - Testing choco pkg is valid"
+choco install infracost2 -dv -s .
+
+$out = (infracost --version)
+if ("Infracost $($version)" -ne $out) {
+  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'Infracost $($version)'"
+  exit 1
+}
+
+Write-Host "$(get-date) - Test install of infracost passed --version check: $($out)"
+
+Get-ChildItem *.nupkg
+Write-Host "$(get-date) - Pushing to Chocolatey"
+choco push -s https://push.chocolatey.org/ --api-key=$env:CHOCO_API_KEY

--- a/infracost2/build.ps1
+++ b/infracost2/build.ps1
@@ -2,11 +2,10 @@
 
 $version = (Invoke-Webrequest https://api.github.com/repos/infracost/cli/releases/latest | convertfrom-json).name
 
-# strip the leading v; the bare version is used as the chocolatey package
-# version and is also embedded in the v2 asset filename
+# strip the leading v; the bare version is used as the chocolatey package version
 $bareVersion = $version.Substring(1, ($version.Length-1))
 
-$zip = "infracost_$($bareVersion)_windows_amd64.zip"
+$zip = "infracost-windows-amd64.zip"
 
 Write-Host "$(get-date) - downloading release $version"
 Invoke-WebRequest -uri "https://github.com/infracost/cli/releases/download/$($version)/$($zip)" -OutFile $zip

--- a/infracost2/templates/chocolateyinstall.ps1
+++ b/infracost2/templates/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-$url64 = "https://github.com/infracost/cli/releases/download/v{PLACEHOLDER_VERSION}/infracost_{PLACEHOLDER_VERSION}_windows_amd64.zip"
+$url64 = "https://github.com/infracost/cli/releases/download/v{PLACEHOLDER_VERSION}/infracost-windows-amd64.zip"
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
 $packageParams = @{

--- a/infracost2/templates/chocolateyinstall.ps1
+++ b/infracost2/templates/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$url64 = "https://github.com/infracost/cli/releases/download/v{PLACEHOLDER_VERSION}/infracost_{PLACEHOLDER_VERSION}_windows_amd64.zip"
+$unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+$packageParams = @{
+  PackageName   = 'infracost2'
+  UnzipLocation = $unzipLocation
+  Url64         = $url64
+  Checksum64    = '{PLACEHOLDER_SHA}'
+  ChecksumType  = 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageParams

--- a/infracost2/templates/infracost2.nuspec
+++ b/infracost2/templates/infracost2.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+	<metadata>
+		<id>infracost2</id>
+		<version>{PLACEHOLDER_VERSION}</version>
+		<packageSourceUrl>https://github.com/infracost/chocolatey-packages</packageSourceUrl>
+		<owners>infracost</owners>
+		<title>Infracost CLI v2</title>
+		<authors>Infracost</authors>
+		<projectUrl>https://infracost.io</projectUrl>
+		<iconUrl>https://rawcdn.githack.com/infracost/chocolatey-packages/master/media/icon.png</iconUrl>
+		<licenseUrl>https://github.com/infracost/cli/blob/main/LICENSE</licenseUrl>
+		<projectSourceUrl>https://github.com/infracost/cli</projectSourceUrl>
+		<docsUrl>https://infracost.io/docs/</docsUrl>
+		<bugTrackerUrl>https://github.com/infracost/cli/issues</bugTrackerUrl>
+		<tags>infracost cloud infrastructure-as-code terraform terragrunt cloudformation iac azure aws cost cost-estimate</tags>
+		<summary>See cloud cost estimates for Terraform, Terragrunt, and CloudFormation in pull requests.</summary>
+		<description>
+			Infracost shows cloud cost estimates from infrastructure as code. It supports Terraform, Terragrunt, and CloudFormation, and enables DevOps, SRE and engineers to see a cost breakdown and understand costs before making changes, either in the terminal or pull requests. This provides your team with a safety net as people can discuss costs as part of the workflow.
+		</description>
+		<releaseNotes>https://github.com/infracost/cli/releases</releaseNotes>
+	</metadata>
+	<files>
+		<file src="tools\**" target="tools" />
+	</files>
+</package>


### PR DESCRIPTION
## Summary

Adds versioned Chocolatey packages mirroring the homebrew `infracost@1` / `infracost@2` split, in support of [DEV-242](https://linear.app/infracost/issue/DEV-242).

- **`infracost1/`** — new package tracking the v1 release line (`infracost/infracost`). Built and pushed alongside the existing unversioned `infracost` package on every v1 release. Uses the same `infracost_choco` `repository_dispatch` already fired by `infracost/infracost`'s `post-release.yml` — no v1 repo changes needed.
- **`infracost2/`** — new package tracking the v2 release line (`infracost/cli`). Listens for a separate `infracost2_choco` dispatch fired by [`infracost/cli` PR #68](https://github.com/infracost/cli/pull/68). Asset URL pattern matches the v2 build artifact naming (`infracost_<version>_windows_amd64.zip`).
- **`.github/workflows/release.yml`** — extended with a parallel `build-v1` job so both `infracost` and `infracost1` are produced from the same v1 dispatch.
- **`.github/workflows/release-v2.yml`** — new workflow listening for `infracost2_choco`, runs `infracost2/build.ps1`.

## How it routes

| Dispatch source | Event type | Workflow | Builds |
|---|---|---|---|
| `infracost/infracost` post-release | `infracost_choco` | `release.yml` | `infracost`, `infracost1` |
| `infracost/cli` post-release | `infracost2_choco` | `release-v2.yml` | `infracost2` |

## After merge

The first `choco push` of each new package id (`infracost1`, `infracost2`) goes through Chocolatey's one-time moderation review. Subsequent pushes for the same id skip moderation. Either let the next natural release trigger the seed push, or fire `release.yml` via `workflow_dispatch` to start moderation early.