### PR TITLE
fix: update v2 build version assertion to match new CLI output

### DIFF
--- a/infracost2/build.ps1
+++ b/infracost2/build.ps1
@@ -30,8 +30,8 @@ Write-Host "$(get-date) - Testing choco pkg is valid"
 choco install infracost2 -dv -s .
 
 $out = (infracost --version)
-if ("Infracost $($version)" -ne $out) {
-  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'Infracost $($version)'"
+if ("infracost version $($bareVersion)" -ne $out) {
+  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'infracost version $($bareVersion)'"
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- The v2 release workflow ([run 25438842437](https://github.com/infracost/chocolatey-packages/actions/runs/25438842437)) failed at the post-install version-string assertion in `infracost2/build.ps1`, exiting before `choco push`. As a result, v2.0.0 was never published to Chocolatey.
- The v2 CLI uses cobra's default `--version` template, emitting `infracost version 2.0.0`, but the script (inherited from the v1 build) expected `Infracost v2.0.0`.
- Updated the assertion to match the actual v2 output. The v1 (`infracost/`, `infracost1/`) build scripts are unchanged.