### PR TITLE
Switch infracost package to track CLI v2

### DIFF
--- a/infracost/build.ps1
+++ b/infracost/build.ps1
@@ -1,43 +1,37 @@
-# this script updates powershell and nuspec files found in the the templates folder to the latest version of Infracost.
+# this script updates powershell and nuspec files found in the templates folder to the latest version of Infracost CLI v2.
+
+$version = (Invoke-Webrequest https://api.github.com/repos/infracost/cli/releases/latest | convertfrom-json).name
+
+# strip the leading v; the bare version is used as the chocolatey package version
+$bareVersion = $version.Substring(1, ($version.Length-1))
 
 $zip = "infracost-windows-amd64.zip"
-$shafile = "$($zip).sha256"
-$version = (Invoke-Webrequest https://api.github.com/repos/infracost/infracost/releases/latest | convertfrom-json).name
 
 Write-Host "$(get-date) - downloading release $version"
-Invoke-WebRequest -uri "https://github.com/infracost/infracost/releases/download/$($version)/$($zip)" -OutFile $zip
-Invoke-WebRequest -uri "https://github.com/infracost/infracost/releases/download/$($version)/$($shafile)" -OutFile $shafile
+Invoke-WebRequest -uri "https://github.com/infracost/cli/releases/download/$($version)/$($zip)" -OutFile $zip
 
 $sha = (Get-FileHash $zip).Hash
-$contents = (Get-Content $shafile)
-if ("$($sha)  $($zip)" -ne $contents) {
-  Write-Host "sha of $($sha) mismatched for downloaded artefact contents: $($contents)"
-  exit 1
-}
 
 if (Test-Path -Path ".\tools") {
   Remove-Item .\tools -Recurse
 }
 New-Item .\tools -ItemType "directory"
 
-# removing the first v as chocolatey doesnt like this version
-$chocoVersion = $version.Substring(1, ($version.Length-1));
-
 function Get-ScriptDirectory { Split-Path $MyInvocation.ScriptName }
 $templatePath = Join-Path (Get-ScriptDirectory) ".\templates"
 
-Get-Content "$($templatePath)\chocolateyinstall.ps1" | %{$_ -replace "{PLACEHOLDER_VERSION}",$version} | %{$_ -replace "{PLACEHOLDER_SHA}", $sha} | Out-File .\tools\chocolateyinstall.ps1
-Get-Content "$($templatePath)\infracost.nuspec" | %{$_ -replace "{PLACEHOLDER_VERSION}",$chocoVersion} | Out-File .\infracost.nuspec
+Get-Content "$($templatePath)\chocolateyinstall.ps1" | %{$_ -replace "{PLACEHOLDER_VERSION}",$bareVersion} | %{$_ -replace "{PLACEHOLDER_SHA}", $sha} | Out-File .\tools\chocolateyinstall.ps1
+Get-Content "$($templatePath)\infracost.nuspec" | %{$_ -replace "{PLACEHOLDER_VERSION}",$bareVersion} | Out-File .\infracost.nuspec
 
 Write-Host "$(get-date) - Building choco pkg"
-choco pack --version $chocoVersion
+choco pack --version $bareVersion
 
 Write-Host "$(get-date) - Testing choco pkg is valid"
 choco install infracost -dv -s .
 
 $out = (infracost --version)
-if ("Infracost $($version)" -ne $out) {
-  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'Infracost $($version)'"
+if ("infracost version $($bareVersion)" -ne $out) {
+  Write-Host "infracost output: $($out) from choco dry run install did not match expected: 'infracost version $($bareVersion)'"
   exit 1
 }
 

--- a/infracost/templates/chocolateyinstall.ps1
+++ b/infracost/templates/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-$url64 = "https://github.com/infracost/infracost/releases/download/{PLACEHOLDER_VERSION}/infracost-windows-amd64.zip"
+$url64 = "https://github.com/infracost/cli/releases/download/v{PLACEHOLDER_VERSION}/infracost-windows-amd64.zip"
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
 $packageParams = @{

--- a/infracost/templates/infracost.nuspec
+++ b/infracost/templates/infracost.nuspec
@@ -10,16 +10,16 @@
 		<authors>Infracost</authors>
 		<projectUrl>https://infracost.io</projectUrl>
 		<iconUrl>https://rawcdn.githack.com/infracost/chocolatey-packages/master/media/icon.png</iconUrl>
-		<licenseUrl>https://github.com/infracost/infracost/blob/master/LICENSE</licenseUrl>
-		<projectSourceUrl>https://github.com/infracost/infracost</projectSourceUrl>
+		<licenseUrl>https://github.com/infracost/cli/blob/main/LICENSE</licenseUrl>
+		<projectSourceUrl>https://github.com/infracost/cli</projectSourceUrl>
 		<docsUrl>https://infracost.io/docs/</docsUrl>
-		<bugTrackerUrl>https://github.com/infracost/infracost/issues</bugTrackerUrl>
-    <tags>infracost cloud infrastructure-as-code terraform iac azure aws cost cost-estimate</tags>
-		<summary>See cloud cost estimates for Terraform in pull requests.</summary>
+		<bugTrackerUrl>https://github.com/infracost/cli/issues</bugTrackerUrl>
+    <tags>infracost cloud infrastructure-as-code terraform terragrunt cloudformation iac azure aws cost cost-estimate</tags>
+		<summary>See cloud cost estimates for Terraform, Terragrunt, and CloudFormation in pull requests.</summary>
 		<description>
-			Infracost shows cloud cost estimates for Terraform. It enables DevOps, SRE and engineers to see a cost breakdown and understand costs before making changes, either in the terminal or pull requests. This provides your team with a safety net as people can discuss costs as part of the workflow.
+			Infracost shows cloud cost estimates from infrastructure as code. It supports Terraform, Terragrunt, and CloudFormation, and enables DevOps, SRE and engineers to see a cost breakdown and understand costs before making changes, either in the terminal or pull requests. This provides your team with a safety net as people can discuss costs as part of the workflow.
 		</description>
-		<releaseNotes>https://github.com/infracost/infracost/releases</releaseNotes>
+		<releaseNotes>https://github.com/infracost/cli/releases</releaseNotes>
 	</metadata>
 	<files>
 		<file src="tools\**" target="tools" />


### PR DESCRIPTION
## Summary

- Repoints the default `infracost` chocolatey package at `infracost/cli` (v2) instead of `infracost/infracost` (v1).
- Mirrors `infracost2/build.ps1`: drops the v1 sha256 sidecar check, uses the bare version for the choco package version, and asserts the new `infracost version X.Y.Z` output.
- Updates `infracost.nuspec` license / source / bug-tracker / release-notes URLs to point at `infracost/cli`, and refreshes the description and tags to mention Terragrunt and CloudFormation.

## Context

The Homebrew maintainers wouldn't let us keep `infracost`, `infracost1`, and `infracost2` formulas side-by-side, so Homebrew's `infracost` now tracks the v2 CLI. This PR makes the default chocolatey package do the same. Chocolatey allows all three ids to coexist, so `infracost1` and `infracost2` stay in place as convenience packages — their build scripts and release workflows are unchanged.