### PR TITLE
Trigger infracost build from v2 release workflow

### DIFF
--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -6,6 +6,16 @@ on:
 
 jobs:
   build:
+    name: Release Infracost choco
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate & push
+        run: infracost/build.ps1
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+
+  build-v2:
     name: Release Infracost CLI v2 choco
     runs-on: windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,6 @@ on:
     types: [infracost_choco]
 
 jobs:
-  build:
-    name: Release Infracost choco
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Generate & push
-        run: infracost/build.ps1
-        env:
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-
   build-v1:
     name: Release Infracost CLI v1 choco
     runs-on: windows-latest


### PR DESCRIPTION
## Summary

- Moves the `Release Infracost choco` job from `release.yml` into `release-v2.yml` so it runs on the `infracost2_choco` repository_dispatch (and manual `workflow_dispatch`) alongside the `infracost2` build.
- `release.yml` now only runs the v1 alias build (`infracost1`).

## Context

Follow-up to #5. Since the default `infracost` chocolatey package now tracks CLI v2, its build should fire on the v2 release dispatch rather than the legacy v1 dispatch.